### PR TITLE
Handle freshly created SRAM with no initialized save files.

### DIFF
--- a/OoTSaveEditor/OoTNameConverter.cs
+++ b/OoTSaveEditor/OoTNameConverter.cs
@@ -40,7 +40,7 @@ namespace HyoutaTools.Other.N64.OoTSaveEditor {
 				if (InternalToChar.TryGetValue(b, out v)) {
 					sb.Append(v);
 				} else {
-					sb.AppendFormat("\\{x2}", b);
+					sb.AppendFormat("{0:x2}", b);
 				}
 			}
 

--- a/OoTSaveEditor/OoTNameConverter.cs
+++ b/OoTSaveEditor/OoTNameConverter.cs
@@ -40,7 +40,7 @@ namespace HyoutaTools.Other.N64.OoTSaveEditor {
 				if (InternalToChar.TryGetValue(b, out v)) {
 					sb.Append(v);
 				} else {
-					sb.AppendFormat("{0:x2}", b);
+					sb.AppendFormat("\\{0:x2}", b);
 				}
 			}
 


### PR DESCRIPTION
In a case where the game was booted with no save files created, the program would crash attempting to convert the player's name from the data, throwing a `System.FormatException` of  `'Input string was not in a correct format.'` A minor adjustment to the stringbuilder's `AppendFormat` resolves this issue.